### PR TITLE
Do not use wxLaunchDefaultBrowser on macOS

### DIFF
--- a/src/manual_pi.cpp
+++ b/src/manual_pi.cpp
@@ -123,10 +123,17 @@ wxString Manual::GetLongDescription() { return PKG_DESCRIPTION; }
 int Manual::GetToolbarToolCount() { return 1; }
 
 void Manual::OnToolbarToolCallback(int id) {
+#ifdef __WXOSX__
+  std::string url("open '");
+  url += GetPluginDataDir(PKG_NAME).ToStdString();
+  url += "/doc/index.html'";
+  wxExecute(url);
+#else
   std::string url("file://");
   url += GetPluginDataDir(PKG_NAME).ToStdString();
   url += "/doc/index.html";
   wxLaunchDefaultBrowser(url);
+#endif
 }
 
 bool Manual::LoadConfig() {


### PR DESCRIPTION
`wxLaunchDefaultBrowser` seems to not work correctly on macOS, replace it with a call to `open <path to index.html>` Fixes #3 