### PR TITLE
correct some offline bad links in some .html files inside /doc folder

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -741,7 +741,8 @@ asciidoc.install();
 <div class="sectionbody">
 <div class="paragraph"><p><a href="./user-manual/opencpn/manual_basic.html">User Manual</a></p></div>
 <div class="paragraph"><p><a href="./plugin-dev-manual/opencpn-plugins/index.html">Plugins Manual</a></p></div>
-<div class="paragraph"><p><a href="./plugin-dev-manual/opencpn-dev/index.html">Development manual</a></p></div>
+<div class="paragraph"><p><a href="./plugin-dev-manual/opencpn-dev/index.html">Core Developer manual</a></p></div>
++<div class="paragraph"><p><a href="./plugin-dev-manual/ocpn-dev-manual/0.1/intro-AboutThisManual.html">Global Developer manual</a></p></div>
 <div class="paragraph"><p>These are downloaded copies from the on-line manuals available at
 <a href="https://opencpn-manuals.github.io/main/manuals/index.html">https://opencpn-manuals.github.io/main/manuals/index.html</a></p></div>
 </div>

--- a/doc/plugin-dev-manual/ocpn-dev-manual/0.1/index.html
+++ b/doc/plugin-dev-manual/ocpn-dev-manual/0.1/index.html
@@ -564,19 +564,19 @@ and several other important links</p>
 <div class="ulist">
 <ul>
 <li>
-<p><a href="https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:manual_basic">User Manual Basic</a></p>
+<p><a href="../../../user-manual/opencpn/manual_basic.html">User Manual Basic</a></p>
 </li>
 <li>
 <p><a href="https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:manual_advanced">User Manual Advanced</a></p>
 </li>
 <li>
-<p><a href="https://opencpn-manuals.github.io/main/opencpn-plugins/index.html">Plugins Manual</a></p>
+<p><a href="../../opencpn-plugins/index.html">Plugins Manual</a></p>
 </li>
 <li>
-<p><a href="https://opencpn-manuals.github.io/main/ocpn-dev-manual/0.1/intro-AboutThisManual.html">Developer Manual</a></p>
+<p><a href="../../ocpn-dev-manual/0.1/intro-AboutThisManual.html">Developer Manual</a></p>
 </li>
 <li>
-<p><a href="https://opencpn-manuals.github.io/main/opencpn-dev/index.html">Opencpn Programming Manual</a></p>
+<p><a href="../../opencpn-dev/index.html">Opencpn Programming Manual</a></p>
 </li>
 </ul>
 </div>

--- a/doc/plugin-dev-manual/ocpn-dev-manual/0.1/intro-AboutThisManual.html
+++ b/doc/plugin-dev-manual/ocpn-dev-manual/0.1/intro-AboutThisManual.html
@@ -547,13 +547,12 @@ to this manual</p>
 <div class="ulist">
 <ul>
 <li>
-<p><a href="https://opencpn.org/wiki/dokuwiki/doku.php?id=opencpn:opencpn_user_manual/">User&#8217;s Manual</a></p>
+<p><a href="../../../user-manual/opencpn/manual_basic.html">User's Manual</a></p>
 </li>
 <li>
-<p><a href="https://opencpn-manuals.github.io/main/opencpn-plugins/index.html">Plugins Manual</a></p>
-</li>
+<p><a href="../../opencpn-plugins/index.html">Plugins Manual</a></p>
 <li>
-<p><a href="https://opencpn-manuals.github.io/main/ocpn-dev-manual/index.html">Developer Manual</a></p>
+<p><a href="./index.html">Developer Manual</a></p>
 </li>
 </ul>
 </div>

--- a/doc/user-manual/opencpn/manual_basic.html
+++ b/doc/user-manual/opencpn/manual_basic.html
@@ -522,7 +522,7 @@
 <div class="sect2">
 <h3 id="_welcome_new_users"><a class="anchor" href="#_welcome_new_users"></a>Welcome new users!</h3>
 <div class="paragraph">
-<p><strong><a href="./quick_start_guide.html#_quick_start_guide">OpenCPN
+<p><strong><a href="./manual_basic/quick_start_guide.html">OpenCPN
 Quick Start Guide</a></strong><br>
 Use your favorite Windows, Mac or Linux desktop or laptop computer.<br>
 === Using this Manual ===</p>
@@ -534,7 +534,7 @@ Use your favorite Windows, Mac or Linux desktop or laptop computer.<br>
 <div class="ulist">
 <ul>
 <li>
-<p>Search box above or <a href="./faq.html">FAQ</a><br></p>
+<p>Search box above or <a href="./manual_basic/faq.html">FAQ</a><br></p>
 </li>
 <li>
 <p>Cell Phones note the "Sidebar" towards the top for Navigation.</p>
@@ -556,7 +556,7 @@ Use your favorite Windows, Mac or Linux desktop or laptop computer.<br>
 <div class="ulist">
 <ul>
 <li>
-<p><a href="/opencpn/manual_basic.html">Basic User Manual</a></p>
+<p><a href="./manual_basic.html">Basic User Manual</a></p>
 <div class="ulist">
 <ul>
 <li>
@@ -571,7 +571,7 @@ Start Guide</a></p>
 2024</p>
 </li>
 <li>
-<p><a href="/opencpn/manual_plugins.html">Plugins (links)</a></p>
+<p><a href="./manual_basic/plugins.html">Plugins (links)</a></p>
 </li>
 <li>
 <p><a href="/opencpn/development_manual.html">Development Manual (links)</a></p>


### PR DESCRIPTION
Hi Alec and Mike

When testing the unarchived /doc folder from manual_pi with Firefox I found some links leading to nowhere...
I have corrected  the bad href inside some lines of these files, tested it locally...
Then I created these commits in my fork...

NB
Antora can't create a good translation for some links needing a relative path offline
When you will update manual_pi these corrections inside the /doc folder will have to be done again ...
 